### PR TITLE
Fix find commands in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,11 @@ deps:
 	pip install -r requirements.txt
 
 clean:
-	rm -fr build \
-	rm -fr dist \
-	find . -name '*.pyc' -exec rm -f {} \
-	find . -name '*.pyo' -exec rm -f {} \
-	find . -name '*~' -exec rm -f {}
+	rm -fr build
+	rm -fr dist
+	find . -name '*.pyc' -exec rm -f {} \;
+	find . -name '*.pyo' -exec rm -f {} \;
+	find . -name '*~' -exec rm -f {} \;
 
 lint:
 	flake8 appname


### PR DESCRIPTION
in make clean all the commands were terminated with a backslash for no
good reason. Also the find commands were missing \; at the end of the
exec which is required.
