### PR TITLE
Specify only toplevel requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 Flask==0.10.1
+
+# Flask Extensions
 Flask-Assets==0.10
 Flask-Cache==0.13.1
 Flask-DebugToolbar==0.9.0
@@ -6,24 +8,17 @@ Flask-Login==0.2.11
 Flask-SQLAlchemy==1.0
 Flask-Script==2.0.5
 Flask-WTF==0.10.0
-Jinja2==2.7.3
-MarkupSafe==0.23
-Pygments==1.6
-SQLAlchemy==0.9.6
-Sphinx==1.2b1
-WTForms==2.0.1
-Werkzeug==0.9.6
-blinker==1.3
-coverage==3.7.1
-cssmin==0.2.0
-docutils==0.12
-flake8==2.0
+
+# Other
 itsdangerous==0.24
+cssmin==0.2.0
 jsmin==2.0.11
-mccabe==0.2.1
-pep8==1.4.6
-py==1.4.22
-pyflakes==0.7.3
+
+# Documentation
+Sphinx==1.2b1
+
+# Testing
 pytest==2.6.0
-webassets==0.10.1
-wsgiref==0.1.2
+coverage==3.7.1
+mccabe==0.2.1
+flake8==2.0


### PR DESCRIPTION
The toplevel requirements already manage their own dependencies. Plus, it makes the `requirements.txt` file easier to read. 
