### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,19 @@
-#Changelog
+# Changelog
 
-##1.2
+## 1.2
 * Added Flask-Login 
 * Added Modernizr
 * updated css and js libraries
 * removed typelate
 
-##1.1
+## 1.1
 * switched to py.test for tests
 * form tests
 * url tests
 * testing database submitting on model tests
 * added documentation on how to deploy your application
 
-##1.0
+## 1.0
 * MVC with blueprints, SQLAlchemy models, and templates
 * A makefile
 * nose tests


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
