### PR TITLE
docs: fix simple typo, supportted -> supported

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -34,7 +34,7 @@ def create_all():
 
 @cli.command()
 def show_urls():
-    """ List all of the endpoints on the app and the supportted methods
+    """ List all of the endpoints on the app and the supported methods
     """
     output = []
     for rule in current_app.url_map.iter_rules():


### PR DESCRIPTION
There is a small typo in manage.py.

Should read `supported` rather than `supportted`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md